### PR TITLE
Adjust android label name

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="src"
+        android:label="FitnessMachine"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity


### PR DESCRIPTION
Change the value of android:label tag in AndroidManifest.xml into "FitnessMachine". This ensures that Android users now see the name “FitnessMachine” instead of “src” for the installed app.