### PR TITLE
Device selection page only closes automatically after the connection is established

### DIFF
--- a/src/lib/hardware/widgets/cubits/fitness_machine_discovery_state.dart
+++ b/src/lib/hardware/widgets/cubits/fitness_machine_discovery_state.dart
@@ -1,0 +1,25 @@
+import '../models/device_descriptor.dart';
+
+class FitnessMachineDiscoveryState {
+  final List<DeviceDescriptor> devices;
+  final DeviceDescriptor? connectingDevice;
+  final DeviceDescriptor? connectedDevice;
+
+  FitnessMachineDiscoveryState({
+    required this.devices,
+    this.connectingDevice,
+    this.connectedDevice,
+  });
+
+  FitnessMachineDiscoveryState copyWith({
+    List<DeviceDescriptor>? devices,
+    DeviceDescriptor? connectingDevice,
+    DeviceDescriptor? connectedDevice,
+  }) {
+    return FitnessMachineDiscoveryState(
+      devices: devices ?? this.devices,
+      connectingDevice: connectingDevice,
+      connectedDevice: connectedDevice,
+    );
+  }
+}


### PR DESCRIPTION
At the moment, the device selection page closes directly after selecting the device and it is displayed that no device is connected.

Adjustments:
- The text “Connecting...” appears next to the clicked device
- The page closes after a successful connection
- The connection status for the selected device is now updated by FitnessMachineCubit